### PR TITLE
Multiple additions

### DIFF
--- a/libpydhcpserver/libpydhcpserver/ipv4_to_iface.py
+++ b/libpydhcpserver/libpydhcpserver/ipv4_to_iface.py
@@ -1,0 +1,86 @@
+"""
+ipv4_to_iface
+=============
+Support for resolving an IPv4 address to a network interface in pure, stdlib
+CPython.
+
+Suitable for use with Linux, FreeBSD, OpenBSD, NetBSD, DragonflyBSD, and
+Mac OS X.
+
+Legal
+=====
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and via any
+medium.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+Authors
+=======
+Neil Tallim <flan@uguu.ca>
+"""
+import ctypes
+import ctypes.util
+import socket
+
+_LIBC = ctypes.CDLL(ctypes.util.find_library('c'))
+
+class struct_sockaddr(ctypes.Structure):
+    _fields_ = (
+        ('sa_family', ctypes.c_ushort),
+    )
+
+class struct_sockaddr_in(ctypes.Structure):
+    _fields_ = (
+        ('sin_family', ctypes.c_ushort),
+        ('sin_port', ctypes.c_uint16),
+        ('sin_addr', ctypes.c_byte * 4),
+    )
+
+class struct_ifaddrs(ctypes.Structure): pass
+struct_ifaddrs._fields_ = (
+        ('ifa_next', ctypes.POINTER(struct_ifaddrs)),
+        ('ifa_name', ctypes.c_char_p),
+        ('ifa_flags', ctypes.c_uint),
+        ('ifa_addr', ctypes.POINTER(struct_sockaddr)),
+    ) #Linux diverges from BSD for the rest, but it's safe to omit the tail
+
+def _is_match(sockaddr, ipv4):
+    if sockaddr.sa_family == socket.AF_INET: #IPv4 address
+        sockaddr_in = ctypes.cast(ctypes.pointer(sockaddr), ctypes.POINTER(struct_sockaddr_in)).contents
+        return socket.inet_ntop(socket.AF_INET, sockaddr_in.sin_addr) == ipv4
+    return False
+
+def get_network_interface(ipv4):
+    """
+    Returns the name of the interface to which the given address is bound, or
+    None if nothing matches.
+    """
+    ifap = ctypes.POINTER(struct_ifaddrs)()
+    if _LIBC.getifaddrs(ctypes.pointer(ifap)): #Non-zero response
+        raise OSError(ctypes.get_errno())
+        
+    try:
+        ifaddr = ifap.contents
+        while True:
+            if _is_match(ifaddr.ifa_addr.contents, ipv4):
+                return ifaddr.ifa_name.decode("utf-8")
+            if not ifaddr.ifa_next:
+                break
+            ifaddr = ifaddr.ifa_next.contents
+    finally:
+        _LIBC.freeifaddrs(ifap)
+    return None
+
+if __name__ == '__main__':
+    import sys
+    print(get_network_interface(sys.argv[1]))

--- a/staticDHCPd/extensions/contrib/tools.py
+++ b/staticDHCPd/extensions/contrib/tools.py
@@ -1,0 +1,44 @@
+"""
+Additional tools for processing DHCP requests
+
+Copyright 2016 NaviSite Inc. - A Time Warner Cable Company
+"""
+import logging
+
+_logger = logging.getLogger('tools')
+
+def filterRetrievedDefinitions(definitions, packet, packet_type, mac,
+                               ip, giaddr, pxe_options):
+    """
+    Filter the possible definitions by using the extra information
+
+    :param list: A list of definitions types to filter
+    :param basestring packet_type: The type of packet being processed.
+    :param str mac: The MAC of the responding interface, in network-byte
+        order.
+    :param :class:`libpydhcpserver.dhcp_types.ipv4.IPv4` ip: Value of
+        DHCP packet's `requested_ip_address` field.
+    :param :class:`libpydhcpserver.dhcp_types.ipv4.IPv4` giaddr: Value of
+        the packet's relay IP address
+    :param namedtuple pxe_options: PXE options
+    :return :class:`databases.generic.Definition` definition: The associated
+        definition; None if no "lease" is available.
+    """
+    if not definitions:
+        return None
+    elif len(definitions) == 1:
+        #replicates current functionality, may want to change
+        return definitions[0]
+
+    for definition in definitions:
+        #TODO: Handle RENEW/REBIND where we know the IP address
+        if giaddr and definition.subnet_mask:
+            #We can determine the correct definition since the
+            # giaddr should exist in the same network as
+            # the response IP address
+            #TODO: What happens under multiple relays in the chain?
+            if giaddr.isSubnetMember(definition.ip, definition.subnet_mask):
+               return definition
+    else:
+        _logger.debug("No match found in filtering.")
+        return None

--- a/staticDHCPd/extensions/official/httpdb.py
+++ b/staticDHCPd/extensions/official/httpdb.py
@@ -34,7 +34,7 @@ to conf.py; if anything more sophisticated is required, fork it and hack away:
         #at a time; successive requests will block; DEFAULTS TO (effectively)
         #INFINITE
         X_HTTPDB_CONCURRENCY_LIMIT = 10
-        
+
 For a list of all parameters you may define, see below.
 
 If concurrent connections to your HTTP server should be limited, use
@@ -80,7 +80,7 @@ def _parse_server_response(json_data):
         ntp_servers=json_data.get('ntp_servers'),
         extra=json_data.get('extra'),
     )
-    
+
 #Do not touch anything below this line
 ################################################################################
 import json
@@ -97,7 +97,7 @@ _logger = logging.getLogger("extension.httpdb")
 class _HTTPLogic(object):
     def __init__(self):
         from staticdhcpdlib import config
-        
+
         try:
             self._uri = config.X_HTTPDB_URI
         except AttributeError:
@@ -106,33 +106,35 @@ class _HTTPLogic(object):
         self._parameters = getattr(config, 'X_HTTPDB_PARAMETERS', {})
         self._parameter_key_mac = getattr(config, 'X_HTTPDB_PARAMETER_KEY_MAC', 'mac')
         self._post = getattr(config, 'X_HTTPDB_POST', True)
-        
+        self._default_name_servers = getattr(config, 'X_HTTPDB_DEFAULT_NAME_SERVERS', '')
+        self._default_lease_time = getattr(config, 'X_HTTPDB_DEFAULT_LEASE_TIME', 0)
+        self._default_serial = getattr(config, 'X_HTTPDB_DEFAULT_SERIAL', 0)
+
     def _lookupMAC(self, mac):
         """
         Performs the actual lookup operation; this is the first thing you should
         study when customising for your site.
         """
         global _parse_server_response
-        
         #If you need to generate per-request headers, add them here
         headers = self._headers.copy()
-        
+
         #To alter the parameters supplied with the request, alter this
         parameters = self._parameters.copy()
-        #Dynamic items 
+        #Dynamic items
         parameters.update({
             self._parameter_key_mac: str(mac),
         })
-        
+
         #You can usually ignore this if-block, though you could strip out whichever method you don't use
         if self._post:
             data = json.dumps(parameters)
-            
+
             headers.update({
                 'Content-Length': str(len(data)),
                 'Content-Type': 'application/json',
             })
-            
+
             request = urllib2.Request(
                 self._uri, data=data,
                 headers=headers,
@@ -145,33 +147,38 @@ class _HTTPLogic(object):
              },
              headers=headers,
             )
-            
-        _logger.debug("Sending request to '%(uri)s' for '%(mac)s'..." % {
+
+        _logger.debug("Sending request to '%(uri)s' for '%(params)s'..." % {
             'uri': self._uri,
-            'mac': str(mac),
+            'params': parameters,
         })
+
         try:
             response = urllib2.urlopen(request)
             _logger.debug("MAC response received from '%(uri)s' for '%(mac)s'" % {
                 'uri': self._uri,
                 'mac': str(mac),
             })
-            result = json.loads(response.read())
-            
-            if not result: #The server sent back 'null' or an empty object
+            results = json.loads(response.read())
+            if not isinstance(results, (list,tuple)):
+                results = [results]
+
+            if not results: #The server sent back 'null' or an empty object
                 _logger.debug("Unknown MAC response from '%(uri)s' for '%(mac)s'" % {
                     'uri': self._uri,
                     'mac': str(mac),
                 })
                 return None
-                
-            definition = _parse_server_response(result)
-            
+
+            _logger.debug("Results from HTTPDB call: %s" % results)
+
             _logger.debug("Known MAC response from '%(uri)s' for '%(mac)s'" % {
                 'uri': self._uri,
                 'mac': str(mac),
             })
-            return definition
+
+            return [_parse_server_response(self._set_defaults(result)) for result in results]
+
         except Exception, e:
             _logger.error("Failed to lookup '%(mac)s' on '%(uri)s': %(error)s" % {
                 'uri': self._uri,
@@ -179,19 +186,35 @@ class _HTTPLogic(object):
                 'error': str(e),
             })
             raise
-            
+
+    def _set_defaults(self, json_data):
+        """
+        Set the default values on a server response if they do not
+         already have usable values
+
+        :param dictionary json_data: Dictionary containing response data
+        :return dictionary: The modified dictionary with defaults
+        """
+        if not json_data.get('serial'):
+            json_data['serial'] = self._default_serial
+        if not json_data.get('domain_name_servers'):
+            json_data['domain_name_servers'] = self._default_name_servers
+        if not json_data.get('lease_time'):
+            json_data['lease_time'] = self._default_lease_time
+        return json_data
+
 class HTTPDatabase(Database, _HTTPLogic):
     def __init__(self):
         _HTTPLogic.__init__(self)
-        
+
     def lookupMAC(self, mac):
         return self._lookupMAC(mac)
-        
+
 class HTTPCachingDatabase(CachingDatabase, _HTTPLogic):
     def __init__(self):
+        from staticdhcpdlib import config
         if hasattr(config, 'X_HTTPDB_CONCURRENCY_LIMIT'):
             CachingDatabase.__init__(self, concurrency_limit=config.X_HTTPDB_CONCURRENCY_LIMIT)
         else:
             CachingDatabase.__init__(self)
         _HTTPLogic.__init__(self)
-        

--- a/staticDHCPd/staticdhcpdlib/config.py
+++ b/staticDHCPd/staticdhcpdlib/config.py
@@ -98,6 +98,11 @@ _defaults.update({
  'PERSISTENT_CACHE': None,
  'CACHE_ON_DISK': False,
 
+ 'MEMCACHED_CACHE': False,
+ 'MEMCACHED_HOST': None,
+ 'MEMCACHED_PORT': 11211,
+ 'MEMCACHED_AGE_TIME': 300, #5 minutes
+
  'CASE_INSENSITIVE_MACS': False,
 
  'EXTRA_MAPS': None,

--- a/staticDHCPd/staticdhcpdlib/databases/_caching.py
+++ b/staticDHCPd/staticdhcpdlib/databases/_caching.py
@@ -3,7 +3,7 @@
 staticdhcpdlib.databases._caching
 =================================
 Defines caching structures for databases.
- 
+
 Legal
 -----
 This file is part of staticDHCPd.
@@ -37,11 +37,11 @@ class _DatabaseCache(Database):
     _cache_lock = None #: A lock to prevent race conditions
     _chained_cache = None #: The next node in the caching chain
     _name = None #: The name of this node
-    
+
     def __init__(self, name, chained_cache=None):
         """
         Initialises a node in a caching chain.
-        
+
         :param basestring name: The name of the cache.
         :param :class:`_DatabaseCache <_DatabaseCache>` chained_cache: The next
             node in the chain; None if this is the end.
@@ -56,14 +56,14 @@ class _DatabaseCache(Database):
             _logger.debug("Chained database-cache: %(chained)s" % {
              'chained': chained_cache,
             })
-            
+
     def __str__(self):
         return "%(name)s <%(type)s : 0x%(id)x>" % {
          'name': self._name,
          'type': self.__class__.__name__,
          'id': id(self),
         }
-        
+
     def reinitialise(self):
         _logger.debug("Reinitialising database-cache '%(id)s'..." % {
          'id': self,
@@ -76,7 +76,7 @@ class _DatabaseCache(Database):
          'id': self,
         })
     def _reinitialise(self): pass
-        
+
     def lookupMAC(self, mac):
         _mac = str(mac)
         _logger.debug("Searching for '%(mac)s' in database-cache '%(id)s'..." % {
@@ -85,7 +85,7 @@ class _DatabaseCache(Database):
         })
         with self._cache_lock:
             definition = self._lookupMAC(mac)
-            
+
         if not definition:
             _logger.debug("No match for '%(mac)s' in database-cache '%(id)s'" % {
              'mac': _mac,
@@ -100,10 +100,10 @@ class _DatabaseCache(Database):
              'mac': _mac,
              'id': self,
             })
-            
+
         return definition
     def _lookupMAC(self, mac): return None
-    
+
     def cacheMAC(self, mac, definition, chained=False):
         _logger.debug("Setting definition for '%(mac)s' in database-cache '%(id)s'..." % {
          'mac': mac,
@@ -111,36 +111,36 @@ class _DatabaseCache(Database):
         })
         with self._cache_lock:
             self._cacheMAC(mac, definition, chained=chained)
-            
+
         if self._chained_cache and not chained:
             self._chained_cache.cacheMAC(mac, definition, chained=False)
     def _cacheMAC(self, mac, definition, chained): pass
-    
+
 class MemoryCache(_DatabaseCache):
     """
     An optimised in-memory database cache.
     """
     _mac_cache = None #: A dictionary of cached MACs
     _subnet_cache = None #: A dictionary of cached subnet/serial data
-    
+
     def __init__(self, name, chained_cache=None):
         """
         Initialises the cache.
-        
+
         :param basestring name: The name of the cache.
         :param :class:`_DatabaseCache <_DatabaseCache>` chained_cache: The next
             node in the chain; None if this is the end.
         """
         _DatabaseCache.__init__(self, name, chained_cache=chained_cache)
-        
+
         self._mac_cache = {}
         self._subnet_cache = {}
         _logger.debug("In-memory database-cache initialised")
-        
+
     def _reinitialise(self):
         self._mac_cache.clear()
         self._subnet_cache.clear()
-        
+
     def _lookupMAC(self, mac):
         data = self._mac_cache.get(int(mac))
         if data:
@@ -154,8 +154,10 @@ class MemoryCache(_DatabaseCache):
              extra=extra
             )
         return None
-        
+
     def _cacheMAC(self, mac, definition, chained):
+        if not isinstance(definition, Definition):
+            raise ValueError('MemoryCache currently only supports caching a single Definition.')
         subnet_id = (definition.subnet, definition.serial)
         self._mac_cache[int(mac)] = (definition.ip, definition.hostname, definition.extra, subnet_id)
         self._subnet_cache[subnet_id] = (
@@ -163,15 +165,15 @@ class MemoryCache(_DatabaseCache):
          definition.domain_name, definition.domain_name_servers, definition.ntp_servers,
          definition.lease_time
         )
-        
+
 class DiskCache(_DatabaseCache):
     _filepath = None #: The path to which the persistent file will be written
     _sqlite3 = None #: A reference to the sqlite3 module
-    
+
     def __init__(self, name, filepath, chained_cache=None):
         """
         Initialises the cache.
-        
+
         :param basestring name: The name of the cache.
         :param basestring filepath: The path to which a persistent on-disk
                                     cache is written; if None, a tempfile is
@@ -180,10 +182,10 @@ class DiskCache(_DatabaseCache):
             node in the chain; None if this is the end.
         """
         _DatabaseCache.__init__(self, name, chained_cache=chained_cache)
-        
+
         import sqlite3
         self._sqlite3 = sqlite3
-        
+
         if filepath:
             self._filepath = filepath
         else:
@@ -191,14 +193,14 @@ class DiskCache(_DatabaseCache):
             #Assigned to self so that the file stays open
             self.__tempfile = tempfile.NamedTemporaryFile()
             self._filepath = self.__tempfile.name
-            
+
         self._setupDatabase()
         _logger.debug("On-disk database-cache initialised at " + self._filepath)
-        
+
     def _connect(self):
         database = self._sqlite3.connect(self._filepath)
         return (database, database.cursor())
-        
+
     def _disconnect(self, database, cursor):
         try:
             cursor.close()
@@ -208,10 +210,10 @@ class DiskCache(_DatabaseCache):
             database.close()
         except Exception, e:
             _logger.warn("Unable to close cache database: " + str(e))
-            
+
     def _setupDatabase(self):
         (database, cursor) = self._connect()
-        
+
         #These definitions omit a lot of integrity logic, since the underlying database is to enforce that
         cursor.execute("""CREATE TABLE IF NOT EXISTS subnets (
     subnet TEXT,
@@ -235,14 +237,14 @@ class DiskCache(_DatabaseCache):
 )""")
         database.commit()
         self._disconnect(database, cursor)
-        
+
     def _reinitialise(self):
         (database, cursor) = self._connect()
         cursor.execute("DELETE FROM maps")
         cursor.execute("DELETE FROM subnets")
         database.commit()
         self._disconnect(database, cursor)
-        
+
     def _lookupMAC(self, mac):
         (database, cursor) = self._connect()
         cursor.execute("""SELECT
@@ -265,8 +267,10 @@ LIMIT 1""", (int(mac),))
              extra=json.loads(result[11])
             )
         return None
-        
+
     def _cacheMAC(self, mac, definition, chained):
+        if not isinstance(definition, Definition):
+            raise ValueError('DiskCache currently only supports caching a single Definition.')
         (database, cursor) = self._connect()
         cursor.execute("INSERT OR IGNORE INTO subnets (subnet, serial, lease_time, gateway, subnet_mask, broadcast_address, ntp_servers, domain_name_servers, domain_name) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
          (
@@ -290,4 +294,3 @@ LIMIT 1""", (int(mac),))
         )
         database.commit()
         self._disconnect(database, cursor)
-        

--- a/staticDHCPd/staticdhcpdlib/dhcp.py
+++ b/staticDHCPd/staticdhcpdlib/dhcp.py
@@ -3,7 +3,7 @@
 staticdhcpdlib.dhcp
 ===================
 Provides the DHCPd side of a staticDHCPd server.
- 
+
 Legal
 -----
 This file is part of staticDHCPd.
@@ -88,7 +88,7 @@ class _PacketWrapper(object):
     _start_time = None #: The time at which processing began.
     _associated_ip = None #: The client-ip associated with this request.
     _definition = None #: The definition associated with this request.
-    
+
     valid = False #: Whether the packet passed basic sanity-tests.
     source_address = None #: The :class:`libpydhcpserver.dhcp.Address` of the packet's origin.
     packet = None #: The packet being wrapped.
@@ -99,11 +99,11 @@ class _PacketWrapper(object):
     giaddr = None #: The IP address of the gateway associated with the packet, if any.
     pxe = None #: Whether the packet was received from a PXE context.
     _pxe_options = None #: Any PXE options extracted from the packet.
-    
+
     def __init__(self, server, packet, packet_type, source_address, pxe):
         """
         Creates a new wrapper.
-        
+
         :param :class:`_DHCPServer` server: The server associated with this
                                             packet.
         :param :class:`libpydhcpserver.dhcp_types.packet.DHCPPacket` packet: The
@@ -114,21 +114,21 @@ class _PacketWrapper(object):
         :param bool pxe: Whether this packet arrived via PXE.
         """
         self._start_time = time.time()
-        
+
         self._server = server
         self._packet_type = packet_type
         self.packet = packet
         self.source_address = source_address
         self.pxe = pxe
-        
+
         self._extractInterestingFields()
-        
+
     def __enter__(self):
         """
         Performs validation on the packet, storing the result in 'valid'.
         """
         self.announcePacket(verbosity=logging.DEBUG)
-        
+
         try:
             self._evaluateSource()
             self._server.evaluateAbuse(self.mac)
@@ -145,14 +145,14 @@ class _PacketWrapper(object):
         else:
             self.valid = True
             self._original_packet = self.packet.copy()
-            
+
         return self
-        
+
     def __exit__(self, type, value, tb):
         """
         Handles logging and notification in the event that processing terminated
         with an exception.
-        
+
         Also ensures that statistical information is assembled and dispatched.
         """
         try:
@@ -172,14 +172,14 @@ class _PacketWrapper(object):
                 'type': self._packet_type,
                 'mac': self.mac,
                 })
-                
+
             time_taken = time.time() - self._start_time
             _logger.debug("%(type)s request from %(mac)s processed in %(seconds).4f seconds" % {
              'type': self._packet_type,
              'mac': self.mac,
              'seconds': time_taken,
             })
-            
+
             if self._definition:
                 ip = self._definition.ip
                 subnet = self._definition.subnet
@@ -190,7 +190,7 @@ class _PacketWrapper(object):
             statistics.emit(statistics.Statistics(
              self.source_address, self.mac, ip, subnet, serial, self._packet_type, time_taken, not self._discarded, self.pxe,
             ))
-            
+
     def _extractInterestingFields(self):
         """
         Pulls commonly needed fields out of the packet, to avoid line-noise in
@@ -211,12 +211,12 @@ class _PacketWrapper(object):
              option_94 and tuple(option_94),
              option_97 and (option_97[0], option_97[1:])
             )
-            
+
     def _evaluateSource(self):
         """
         Determines whether the received packet belongs to a relayed request or
         not and decides whether it should be allowed based on policy.
-        
+
         :except _PacketSourceUnacceptable: The packet was rejected.
         """
         if self.giaddr: #Relayed request.
@@ -226,11 +226,11 @@ class _PacketWrapper(object):
                 raise _PacketSourceUnacceptable("relay not authorised")
         elif not config.ALLOW_LOCAL_DHCP and not self.pxe: #Local request, but denied.
             raise _PacketSourceUnacceptable("neither link-local traffic nor PXE is enabled")
-            
+
     def announcePacket(self, ip=None, verbosity=logging.INFO):
         """
         Logs the occurance of the wrapped packet.
-        
+
         :param basestring ip: The IP for which the request was sent, if known.
         :param int verbosity: A logging severity constant.
         """
@@ -245,33 +245,33 @@ class _PacketWrapper(object):
          ),
          'pxe': self.pxe and " (PXE)" or '',
         })
-        
+
     def getType(self):
         """
         Provides the type of packet being processed.
-        
+
         :return basestring: The type of packet being processed.
         """
         return self._packet_type
-        
+
     def setType(self, packet_type):
         """
         Updates the type of packet being processed.
-        
+
         :param basestring packet_type: The type of packet being processed.
         """
         self._packet_type = packet_type
-        
+
     def markAddressed(self):
         """
         Indicate that the packet was processed to completion.
         """
         self._discarded = False
-        
+
     def filterPacket(self, override_ip=False, override_ip_value=None):
         """
         A mechanism for allowing user-defined packet-filtering functionality.
-        
+
         :param bool override_ip: True if the advertised client IP should be
                                  overridden with another value.
         :param :class:`libpydhcpserver.dhcp_types.packet.DHCPPacket` override_ip_value: The
@@ -284,7 +284,7 @@ class _PacketWrapper(object):
         if override_ip:
             ip = override_ip_value
             self._associated_ip = ip
-            
+
         result = config.filterPacket(
          self.packet, self._packet_type,
          self.mac, ip, self.giaddr,
@@ -293,11 +293,11 @@ class _PacketWrapper(object):
         if result is None:
             raise _PacketSourceBlacklist("filterPacket() returned None")
         return result
-        
+
     def _loadDHCPPacket(self, definition, inform):
         """
         Sets option fields based on values returned from a database.
-        
+
         :param :class:`databases.generic.Definition` definition: Parameters used
             to load the packet.
         :param bool inform: True if this is a response to an INFORM request,
@@ -307,7 +307,7 @@ class _PacketWrapper(object):
         if not inform:
             self.packet.setOption('yiaddr', definition.ip)
             self.packet.setOption(51, definition.lease_time)
-            
+
         #Default gateway, subnet mask, and broadcast address.
         if definition.gateways:
             self.packet.setOption(3, definition.gateways)
@@ -315,7 +315,7 @@ class _PacketWrapper(object):
             self.packet.setOption(1, definition.subnet_mask)
         if definition.broadcast_address:
             self.packet.setOption(28, definition.broadcast_address)
-            
+
         #Domain details.
         if definition.hostname:
             self.packet.setOption(12, definition.hostname)
@@ -323,16 +323,16 @@ class _PacketWrapper(object):
             self.packet.setOption(15, definition.domain_name)
         if definition.domain_name_servers:
             self.packet.setOption(6, definition.domain_name_servers)
-            
+
         #NTP servers.
         if definition.ntp_servers:
             self.packet.setOption(42, definition.ntp_servers)
-            
+
     def loadDHCPPacket(self, definition, inform=False):
         """
         Loads the packet with all normally required values, then passes it
         through user-defined scripting to further set fields as needed.
-        
+
         :param :class:`databases.generic.Definition` definition: Parameters used
             to load the packet.
         :param bool inform: True if this is a response to an INFORM request.
@@ -351,12 +351,12 @@ class _PacketWrapper(object):
              'mac': self.mac,
             })
         return process
-        
+
     def retrieveDefinition(self, override_ip=False, override_ip_value=None):
         """
         Queries the database and user-defined scripting to try to match the MAC
         to a "lease".
-        
+
         :param bool override_ip: If True, `override_ip_value` will be used
             instead of the packet's `requested_ip_address` field.
         :param :class:`libpydhcpserver.dhcp_types.packet.DHCPPacket` override_ip_value: The
@@ -368,19 +368,30 @@ class _PacketWrapper(object):
         if override_ip:
             ip = override_ip_value
             self._associated_ip = ip
-            
-        self._definition = self._server.getDatabase().lookupMAC(self.mac) or config.handleUnknownMAC(
+
+        definition = self._server.getDatabase().lookupMAC(self.mac) or config.handleUnknownMAC(
          self.packet, self._packet_type,
          self.mac, ip, self.giaddr,
          self.pxe and self._pxe_options or None
         )
-        
+
+        #Allow for DBs to return multiple definitions that can then
+        # be filtered based on the the additional information
+        if definition and isinstance(definition, (list,tuple)):
+            _logger.debug('Multiple (%s) definitions found', len(definition))
+            self._definition = config.filterRetrievedDefinitions(
+             definition, self.packet, self._packet_type, self.mac, ip,
+             self.giaddr, self.pxe and self._pxe_options or None
+            )
+        else:
+            self._definition = definition or None
+
         return self._definition
-        
+
 def _dhcpHandler(packet_type):
     """
     A decorator to abstract away the wrapper boilerplate.
-    
+
     :param basestring packet_type: The type of packet initially being processed.
     """
     def decorator(f):
@@ -391,7 +402,7 @@ def _dhcpHandler(packet_type):
                 f(self, wrapper)
         return wrappedHandler
     return decorator
-    
+
 class _DHCPServer(libpydhcpserver.dhcp.DHCPServer):
     """
     The handler that responds to all received requests.
@@ -400,11 +411,11 @@ class _DHCPServer(libpydhcpserver.dhcp.DHCPServer):
     _database = None #: The database to use for retrieving lease definitions.
     _dhcp_actions = None #: The MACs and the number of actions each has performed, decremented by one each tick.
     _ignored_addresses = None #: A list of all MACs currently ignored, plus the time remaining until requests will be honoured again.
-    
+
     def __init__(self, server_address, server_port, client_port, pxe_port, response_interface, response_interface_qtags, database):
         """
         Constructs the handler.
-        
+
         :param basestring address: The IP of the interface from which responses
                                    are to be sent.
         :param int server_port: The port on which DHCP requests are expected to
@@ -422,29 +433,29 @@ class _DHCPServer(libpydhcpserver.dhcp.DHCPServer):
         self._database = database
         self._dhcp_actions = {}
         self._ignored_addresses = []
-        
+
         libpydhcpserver.dhcp.DHCPServer.__init__(
          self, server_address, server_port, client_port, pxe_port, response_interface=response_interface, response_interface_qtags=response_interface_qtags
         )
-        
+
     @_dhcpHandler(_PACKET_TYPE_DECLINE)
     def _handleDHCPDecline(self, wrapper):
         """
         Informs the operator of a potential IP collision on the network.
-        
+
         :param :class:`_PacketWrapper` wrapper: The wrapped packet to process.
         :except _PacketSourceBlacklist: The MAC appears to be generating false
                                         information to disrupt the network.
         """
         if not wrapper.ip:
             raise _PacketSourceBlacklist("conflicting IP was not specified")
-            
+
         if not wrapper.sid:
             raise _PacketSourceBlacklist("server-identifier was not specified")
-            
+
         if wrapper.sid == self._server_address: #Rejected!
             if not wrapper.filterPacket(): return
-            
+
             definition = wrapper.retrieveDefinition()
             if definition and definition.ip == wrapper.ip: #Known client.
                 _logger.error('%(type)s from %(mac)s for %(ip)s on (%(subnet)s, %(serial)i)' % {
@@ -468,20 +479,20 @@ class _DHCPServer(libpydhcpserver.dhcp.DHCPServer):
                  'ip': wrapper.ip,
                  'mac': wrapper.mac,
                 })
-                
+
     @_dhcpHandler(_PACKET_TYPE_DISCOVER)
     def _handleDHCPDiscover(self, wrapper):
         """
         Evaluates a DISCOVER request from a client and determines whether an
         OFFER should be sent.
-        
+
         :param :class:`_PacketWrapper` wrapper: The wrapped packet to process.
         :except _PacketSourceBlacklist: The MAC can't be handled, but it also
                                         can't be NAKed, so reduce load.
         """
         if not wrapper.filterPacket(override_ip=True, override_ip_value=None): return
         wrapper.announcePacket()
-        
+
         definition = wrapper.retrieveDefinition(override_ip=True, override_ip_value=None)
         if definition:
             rapid_commit = wrapper.packet.isOption(80)
@@ -494,7 +505,7 @@ class _DHCPServer(libpydhcpserver.dhcp.DHCPServer):
                 wrapper.packet.setOption(80, [])
             else:
                 wrapper.packet.transformToDHCPOfferPacket()
-                
+
             if wrapper.loadDHCPPacket(definition):
                 if rapid_commit:
                     self._emitDHCPPacket(
@@ -517,23 +528,23 @@ class _DHCPServer(libpydhcpserver.dhcp.DHCPServer):
                 wrapper.markAddressed()
             else:
                 raise _PacketSourceBlacklist("unknown MAC and server is not authoritative; ignoring because rejection is impossible")
-                
+
     @_dhcpHandler(_PACKET_TYPE_INFORM)
     def _handleDHCPInform(self, wrapper):
         """
         Evaluates an INFORM request from a client and determines whether an ACK
         should be sent.
-        
+
         :param :class:`_PacketWrapper` wrapper: The wrapped packet to process.
         :except _PacketSourceBlacklist: The MAC can't be handled, so reduce
                                         load.
         """
         if not wrapper.filterPacket(override_ip=True, override_ip_value=wrapper.ciaddr): return
         wrapper.announcePacket(ip=wrapper.ciaddr)
-        
+
         if not wrapper.ciaddr:
             raise _PacketSourceBlacklist("ciaddr was not specified")
-            
+
         definition = wrapper.retrieveDefinition(override_ip=True, override_ip_value=wrapper.ciaddr)
         if definition:
             wrapper.packet.transformToDHCPAckPacket()
@@ -545,30 +556,30 @@ class _DHCPServer(libpydhcpserver.dhcp.DHCPServer):
                 wrapper.markAddressed()
         else:
             raise _PacketSourceBlacklist("unknown MAC")
-            
+
     @_dhcpHandler(_PACKET_TYPE_LEASEQUERY)
     def _handleDHCPLeaseQuery(self, wrapper):
         """
         Simply discards the packet; LEASEQUERY support was dropped in 1.7.0,
         because the implementation was wrong.
-        
+
         :param :class:`_PacketWrapper` wrapper: The wrapped packet to process.
         """
         if not wrapper.filterPacket(): return
         wrapper.announcePacket()
-        
+
         #When reimplementing LEASEQUERY, create an alternative to the
         #'Definition' model and use that to transfer data through the wrapper
         #and handleUnknownMAC. Instead of retrieveDefinition(), it will be
         #retrieveLeaseDefinition() and handleUnknownMAC() will need to return
         #that as a third result. Its None still means it had nothing, though.
-        
+
     @_dhcpHandler(_PACKET_TYPE_REQUEST)
     def _handleDHCPRequest(self, wrapper):
         """
         Evaluates a REQUEST request from a client and determines whether an ACK
         should be sent.
-        
+
         :param :class:`_PacketWrapper` wrapper: The wrapped packet to process.
         """
         if wrapper.sid and not wrapper.ciaddr: #SELECTING
@@ -585,19 +596,19 @@ class _DHCPServer(libpydhcpserver.dhcp.DHCPServer):
              'ip': wrapper.ip,
              'mac': wrapper.mac,
             })
-            
+
     def _handleDHCPRequest_SELECTING(self, wrapper):
         """
         Evaluates a SELECTING REQUEST from a client and determines whether an
         ACK or NAK should be sent.
-        
+
         :param :class:`_PacketWrapper` wrapper: The wrapped packet to process.
         """
         wrapper.setType(_PACKET_TYPE_REQUEST_SELECTING)
         if wrapper.sid == self._server_address: #Chosen!
             if not wrapper.filterPacket(): return
             wrapper.announcePacket(ip=wrapper.ip)
-            
+
             definition = wrapper.retrieveDefinition()
             if definition and (not wrapper.ip or definition.ip == wrapper.ip):
                 wrapper.packet.transformToDHCPAckPacket()
@@ -614,18 +625,18 @@ class _DHCPServer(libpydhcpserver.dhcp.DHCPServer):
                  wrapper.mac, _IP_REJECTED
                 )
                 wrapper.markAddressed()
-                
+
     def _handleDHCPRequest_INIT_REBOOT(self, wrapper):
         """
         Evaluates and an INIT-REBOOT REQUEST from a client and determines
         whether an ACK or NAK should be sent.
-        
+
         :param :class:`_PacketWrapper` wrapper: The wrapped packet to process.
         """
         wrapper.setType(_PACKET_TYPE_REQUEST_INIT_REBOOT)
         if not wrapper.filterPacket(): return
         wrapper.announcePacket(ip=wrapper.ip)
-        
+
         definition = wrapper.retrieveDefinition()
         if definition and definition.ip == wrapper.ip:
             wrapper.packet.transformToDHCPAckPacket()
@@ -642,22 +653,22 @@ class _DHCPServer(libpydhcpserver.dhcp.DHCPServer):
              wrapper.mac, wrapper.ip
             )
             wrapper.markAddressed()
-            
+
     def _handleDHCPRequest_RENEW_REBIND(self, wrapper):
         """
         Evaluates a RENEW or REBIND REQUEST from a client and determines whether
         an ACK or NAK should be sent.
-        
+
         If policy forbids RENEW and REBIND operations, perhaps to prepare for a
         new configuration rollout, all such requests are NAKed immediately.
-        
+
         :param :class:`_PacketWrapper` wrapper: The wrapped packet to process.
         """
         renew = wrapper.source_address.ip not in libpydhcpserver.dhcp.IP_UNSPECIFIED_FILTER
         wrapper.setType(renew and _PACKET_TYPE_REQUEST_RENEW or _PACKET_TYPE_REQUEST_REBIND)
         if not wrapper.filterPacket(): return
         wrapper.announcePacket(ip=wrapper.ip)
-        
+
         if config.NAK_RENEWALS and not wrapper.pxe and (renew or config.AUTHORITATIVE):
             wrapper.packet.transformToDHCPNakPacket()
             self._emitDHCPPacket(
@@ -686,19 +697,19 @@ class _DHCPServer(libpydhcpserver.dhcp.DHCPServer):
                      wrapper.mac, wrapper.ciaddr
                     )
                     wrapper.markAddressed()
-                    
+
     @_dhcpHandler(_PACKET_TYPE_RELEASE)
     def _handleDHCPRelease(self, wrapper):
         """
         Evaluates a RELEASE request, sent when a client terminates its "lease".
-        
+
         :param :class:`_PacketWrapper` wrapper: The wrapped packet to process.
         :except _PacketSourceBlacklist: The MAC appears to be generating false
                                         information to disrupt the network.
         """
         if not wrapper.sid:
             raise _PacketSourceBlacklist("server-identifier was not specified")
-            
+
         if wrapper.sid == self._server_address: #Released!
             if not wrapper.filterPacket(override_ip=True, override_ip_value=wrapper.ciaddr): return
             definition = wrapper.retrieveDefinition(override_ip=True, override_ip_value=wrapper.ciaddr)
@@ -711,14 +722,14 @@ class _DHCPServer(libpydhcpserver.dhcp.DHCPServer):
                  'ip': wrapper.ciaddr,
                  'mac': wrapper.mac,
                 })
-                
+
     def _logDHCPAccess(self, mac):
         """
         Increments the number of times the given MAC address has accessed this
         server. If suspension is enabled and the value exceeds the policy
         threshold, the MAC is ignored as potentially belonging to a malicious
         system.
-        
+
         :param :class:`libpydhcpserver.dhcp_types.mac.MAC` mac: The MAC being
                                                                 evaluated.
         :return bool: True if the MAC's request should be processed.
@@ -739,12 +750,12 @@ class _DHCPServer(libpydhcpserver.dhcp.DHCPServer):
                         self._ignored_addresses.append([minimal_mac, config.MISBEHAVING_CLIENT_TIMEOUT])
                         return False
         return True
-        
+
     def _emitDHCPPacket(self, packet, address, pxe, mac, client_ip):
         """
         Sends the given packet to the right destination, based on its
         properties.
-        
+
         :param :class:`libpydhcpserver.dhcp_types.packet.DHCPPacket` packet: The
             packet to be transmitted.
         :param :class:`libpydhcpserver.dhcp.Address` address: The address from
@@ -758,7 +769,7 @@ class _DHCPServer(libpydhcpserver.dhcp.DHCPServer):
         :return int: The number of bytes emitted.
         """
         packet.setOption(54, self._server_address) #server_identifier
-        
+
         (bytes, address) = self._sendDHCPPacket(packet, address, pxe)
         response_type = packet.getDHCPMessageTypeName()
         _logger.info('%(type)s sent at %(mac)s for %(client)s via %(ip)s:%(port)i %(pxe)s[%(bytes)i bytes]' % {
@@ -771,11 +782,11 @@ class _DHCPServer(libpydhcpserver.dhcp.DHCPServer):
          'pxe': pxe and '(PXE) ' or '',
         })
         return bytes
-        
+
     def addToTempBlacklist(self, mac, packet_type, reason):
         """
         Marks a MAC as ignorable for a brief period of time.
-        
+
         :param :class:`libpydhcpserver.dhcp_types.mac.MAC` mac: The MAC to be
                                                                 ignored.
         """
@@ -787,11 +798,11 @@ class _DHCPServer(libpydhcpserver.dhcp.DHCPServer):
          'packet_type': packet_type,
          'reason': reason,
         })
-        
+
     def evaluateAbuse(self, mac):
         """
         Determines whether the MAC is, or should be, blacklisted.
-        
+
         :param :class:`libpydhcpserver.dhcp_types.mac.MAC` mac: The MAC to be
                                                                 evaluated.
         :except _PacketSourceIgnored: The MAC is currently being ignored.
@@ -800,19 +811,19 @@ class _DHCPServer(libpydhcpserver.dhcp.DHCPServer):
             ignored = [timeout for (ignored_mac, timeout) in self._ignored_addresses if mac == ignored_mac]
         if ignored:
             raise _PacketSourceIgnored("MAC is on cooldown for another %(count)i seconds" % {'count': max(ignored)})
-            
+
         if not self._logDHCPAccess(mac):
             raise _PacketSourceIgnored("MAC has been ignored for excessive activity")
-            
+
     def getDatabase(self):
         """
         Returns the database this server is configured to use.
-        
+
         :return :class:`databases.generic.Database`: The database used for
             retrieving lease definitions.
         """
         return self._database
-        
+
     def getNextDHCPPacket(self):
         """
         Listens for a DHCP packet and initiates processing upon receipt.
@@ -822,7 +833,7 @@ class _DHCPServer(libpydhcpserver.dhcp.DHCPServer):
             statistics.emit(statistics.Statistics(
              source_address, None, None, None, None, None, 0.0, False, False
             ))
-            
+
     def tick(self):
         """
         Cleans up the MAC blacklist and the abuse-monitoring list.
@@ -834,7 +845,7 @@ class _DHCPServer(libpydhcpserver.dhcp.DHCPServer):
                     del self._ignored_addresses[i]
                 else:
                     ignored_address[1] -= 1
-                    
+
             if config.ENABLE_SUSPEND:
                 dead_keys = []
                 for (k, v) in self._dhcp_actions.iteritems():
@@ -842,21 +853,21 @@ class _DHCPServer(libpydhcpserver.dhcp.DHCPServer):
                         dead_keys.append(k)
                     else:
                         self._dhcp_actions[k] -= 1
-                        
+
                 for k in dead_keys:
                     del self._dhcp_actions[k]
-                    
-                    
+
+
 class DHCPService(threading.Thread):
     """
     A thread that handles DHCP requests indefinitely, daemonically.
     """
     _dhcp_server = None #: The handler that responds to DHCP requests.
-    
+
     def __init__(self, database):
         """
         Sets up the DHCP server.
-        
+
         :param :class:`databases.generic.Database` database: The database to use
                                                              for retrieving
                                                              lease definitions.
@@ -866,7 +877,7 @@ class DHCPService(threading.Thread):
         threading.Thread.__init__(self)
         self.name = "DHCP"
         self.daemon = True
-        
+
         server_address = IPv4(config.DHCP_SERVER_IP)
         _logger.info("Prepared to bind to %(address)s; ports: server: %(server)s, client: %(client)s, pxe: %(pxe)s%(response-interface)s" % {
          'address': server_address,
@@ -890,11 +901,11 @@ class DHCPService(threading.Thread):
          database
         )
         _logger.info("Configured DHCP server")
-        
+
     def run(self):
         """
         Runs the DHCP server indefinitely.
-        
+
         In the event of an unexpected error, e-mail will be sent and processing
         will continue with the next request.
         """
@@ -906,13 +917,13 @@ class DHCPService(threading.Thread):
                 _logger.debug('Suppressed non-fatal select() error')
             except Exception:
                 _logger.critical("Unhandled exception:\n" + traceback.format_exc())
-                
+
     def tick(self):
         """
         Calls the underlying tick() method.
         """
         self._dhcp_server.tick()
-    
+
 class _PacketRejection(Exception):
     """
     The base-class for indicating that a packet could not be processed.
@@ -929,4 +940,3 @@ class _PacketSourceUnacceptable(_PacketRejection):
     """
     Indicates that the packet's sender is not permitted by policy.
     """
-    


### PR DESCRIPTION
Allow for database fetches to return a list or tuple of definitions. This is possible in the case that a specific MAC address is duplicated across different subnets. A filterRetrievedDefinitions function can be defined to filter based on giaddr in the case a relay is on each network. 

Update HTTPDB to return a list of definitions. 

Provide a memcached cacher implementation. 

Enhance ability to listen on a specific interface (thanks flan!). 
