### PR TITLE
Stop tracebacks if vendor_specific is not set

### DIFF
--- a/staticDHCPd/staticdhcpdlib/config.py
+++ b/staticDHCPd/staticdhcpdlib/config.py
@@ -237,10 +237,11 @@ if hasattr(conf, 'loadDHCPPacket'):
         
         def loadDHCPPacket(packet, method, mac, definition, relay_ip, port, source_packet):
             vendor_class = None
+            vendor_specific = None
             if source_packet.isOption('vendor_class'):
                 vendor_class = tuple(sorted(source_packet.getOption('vendor_class', convert=True).items()))
-            if source_packet.isOption('vendor_class_identifier'):
-                vendor_class_identifier = tuple((k, tuple(sorted(v.items()))) for (k, v) in sorted(source_packet.getOption('vendor_specific', convert=True).items()))
+            if source_packet.isOption('vendor_specific'):
+                vendor_specific = tuple((k, tuple(sorted(v.items()))) for (k, v) in sorted(source_packet.getOption('vendor_specific', convert=True).items()))
                 
             pxe_options = None
             if port == PROXY_PORT:
@@ -260,7 +261,7 @@ if hasattr(conf, 'loadDHCPPacket'):
                     source_packet.getOption('vendor_specific_information'),
                     source_packet.getOption('vendor_class_identifier', convert=True),
                     vendor_class,
-                    vendor_class_identifier,
+                    vendor_specific,
                 ),
             )
     else:


### PR DESCRIPTION
My ipxe client is sending vendor_class_identifier but not
vendor_specific which leads to a exception when serving dhcp:

AttributeError: 'NoneType' object has no attribute 'items'

Wrap the extractiong of vendor_specific with a check to see if it
exists instead of a check to see if vendor_class_identifier exists.
